### PR TITLE
Test for positive "by", see issue 300

### DIFF
--- a/ansi-tests/loop1.lsp
+++ b/ansi-tests/loop1.lsp
@@ -358,4 +358,17 @@
    (loop for i from 1 below (expand-in-current-env (%m 5)) collect i))
   (1 2 3 4))
 
-  
+;;; http://www.lispworks.com/documentation/lw51/CLHS/Body/06_abaa.htm
+;;; by The loop keyword by marks the increment or decrement supplied by form3.
+;;; The value of form3 can be any positive number. The default value is 1.
+(deftest loop.1.66
+  (signals-error
+   (loop for i below 10 for j by 0 collect (list i j))
+   program-error)
+  t)
+
+(deftest loop.1.67
+  (signals-error
+   (loop for i below 10 for j by -1 collect (list i j))
+   program-error)
+  t)  


### PR DESCRIPTION
* test for pr https://github.com/Clozure/ccl/pull/307 as requested by phoe
Execution without pr #307:
```lisp
? (run-tests)
; Warning: Redefining test CCL.ISSUE\#167
; While executing: REGRESSION-TEST::REPORT-ERROR, in process listener(1).
Doing 21910 pending tests of 21910 tests total.

Test CL-TEST::LOOP.1.66 failed
Form: (CL-TEST:SIGNALS-ERROR (LOOP CL-TEST::FOR CL-TEST::I CL-TEST::BELOW 10 CL-TEST::FOR CL-TEST::J CL-TEST::BY 0 CL-TEST::COLLECT (LIST CL-TEST::I CL-TEST::J)) PROGRAM-ERROR)
Expected value: T
Actual values: NIL
               ((0 0) (1 0) (2 0) (3 0) (4 0) (5 0) (6 0) (7 0) (8 0) (9 0)).

Test CL-TEST::LOOP.1.67 failed
Form: (CL-TEST:SIGNALS-ERROR (LOOP CL-TEST::FOR CL-TEST::I CL-TEST::BELOW 10 CL-TEST::FOR CL-TEST::J CL-TEST::BY -1 CL-TEST::COLLECT (LIST CL-TEST::I CL-TEST::J)) PROGRAM-ERROR)
Expected value: T
Actual values: NIL
               ((0 0) (1 -1) (2 -2) (3 -3) (4 -4) (5 -5) (6 -6) (7 -7) (8 -8) (9 -9)).
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C12D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C12D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C12D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C12D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C12D>

================ Test suite failed ================

2 out of 21910 total tests failed: 
   CL-TEST::LOOP.1.66, CL-TEST::LOOP.1.67.
(FUNCALL DO-TESTS :COMPILE COMPILE :VERBOSE VERBOSE :CATCH-ERRORS T)
took 158,985,489 microseconds (158.985490 seconds) to run.
       2,299,738 microseconds (  2.299738 seconds, 1.45%) of which was spent in GC.
During that period, and with 8 available CPU cores,
     149,547,202 microseconds (149.547200 seconds) were spent in user mode
       9,345,163 microseconds (  9.345163 seconds) were spent in system mode
 7,717,286,224 bytes of memory allocated.
 22,525 minor page faults, 0 major page faults, 0 swaps.
(CL-TEST::LOOP.1.67 CL-TEST::LOOP.1.66)
````

Execution with Pr #307:
```lisp
? (run-tests)
; Warning: Redefining test CCL.ISSUE\#167
; While executing: REGRESSION-TEST::REPORT-ERROR, in process listener(1).
Doing 21910 pending tests of 21910 tests total.
Invoking restart: #<RESTART CL-TEST::FOO #x7CD12D>
Invoking restart: #<RESTART CL-TEST::FOO #x7CD12D>
Invoking restart: #<RESTART CL-TEST::FOO #x7CD12D>
Invoking restart: #<RESTART CL-TEST::FOO #x7CD12D>
Invoking restart: #<RESTART CL-TEST::FOO #x7CD12D>

=============== All tests succeeded ===============

(FUNCALL DO-TESTS :COMPILE COMPILE :VERBOSE VERBOSE :CATCH-ERRORS T)
took 163,050,678 microseconds (163.050670 seconds) to run.
       2,399,547 microseconds (  2.399547 seconds, 1.47%) of which was spent in GC.
During that period, and with 8 available CPU cores,
     153,262,108 microseconds (153.262120 seconds) were spent in user mode
       9,794,791 microseconds (  9.794791 seconds) were spent in system mode
 7,717,011,968 bytes of memory allocated.
 22,661 minor page faults, 0 major page faults, 0 swaps.
NIL
````